### PR TITLE
Allow to connect do different BrowserStack compatible API servers

### DIFF
--- a/lib/browserstack.js
+++ b/lib/browserstack.js
@@ -30,6 +30,11 @@ function Client( settings ) {
 	extend( this, settings );
 	this.authHeader = "Basic " +
 		new Buffer( this.username + ":" + this.password ).toString( "base64" );
+
+	this.server = extend({
+		host: "api.browserstack.com",
+		port: 80
+	}, this.server || {});
 }
 
 
@@ -142,8 +147,8 @@ extend( Client.prototype, {
 		fn = fn || function() {};
 
 		var req = http.request( extend({
-			host: "api.browserstack.com",
-			port: 80,
+			host: this.server.host,
+			port: this.server.port,
 			method: "GET",
 			headers: {
 				authorization: this.authHeader,

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,8 @@ Creates a new client instance.
   * `username`: The username for the BrowserStack account.
   * `password`: The password for the BrowserStack account.
   * `version` (optional; default: `2`): Which version of the BrowserStack API to use.
+  * `server` (optional; default: `{ host : "api.browserstack.com", port : 80 }`):
+  An object containing `host` and `port` to connect to a different browserstack API compatible service.
 
 ### client.getBrowsers( callback )
 


### PR DESCRIPTION
This is an updated version of pull request #5 to allow connecting to a different server that provides a BrowserStack compatible API. Usage:

```
BrowserStack.createClient({
    username : '',
    password : '',
    server : {
        port : 8080,
        host : 'localhost'
    }
});
```
