### PR TITLE
use https by default and accept apiKey instead of password

### DIFF
--- a/lib/browserstack.js
+++ b/lib/browserstack.js
@@ -1,4 +1,4 @@
-var http = require( "http" ),
+var https = require( "https" ),
 	querystring = require( "querystring" ),
 	util = require( "util" ),
 	userAgent = getUA();
@@ -21,19 +21,19 @@ function extend( a, b ) {
 
 function Client( settings ) {
 	if ( !settings.username ) {
-		throw new Error( "Username is required." );
+		throw new Error( "username is required." );
 	}
-	if ( !settings.password ) {
-		throw new Error( "Password is required." );
+	if ( !settings.password && !settings.apiKey ) {
+		throw new Error( "password or apiKey is required." );
 	}
 
 	extend( this, settings );
 	this.authHeader = "Basic " +
-		new Buffer( this.username + ":" + this.password ).toString( "base64" );
+		new Buffer( this.username + ":" + (this.password || this.apiKey) ).toString( "base64" );
 
 	this.server = extend({
 		host: "api.browserstack.com",
-		port: 80
+		port: 443
 	}, this.server || {});
 }
 
@@ -152,7 +152,7 @@ extend( Client.prototype, {
 		}
 		fn = fn || function() {};
 
-		var req = http.request( extend({
+		var req = https.request( extend({
 			host: this.server.host,
 			port: this.server.port,
 			method: "GET",


### PR DESCRIPTION
Since we are doing basic authentication use HTTPS to not send my password as a clear text.

Also, BrowserStack supports doing basic auth with the apiKey instead of the password, I changed the api a little bit to reflect this.

Thanks
