### PR TITLE
Add change url support

### DIFF
--- a/lib/browserstack.js
+++ b/lib/browserstack.js
@@ -1,5 +1,4 @@
 var http = require( "http" ),
-	querystring = require( "querystring" ),
 	util = require( "util" ),
 	userAgent = getUA();
 
@@ -79,7 +78,7 @@ extend( Client.prototype, {
 
 	changeUrl: function( id, options, fn ) {
 		var data = JSON.stringify( options );
-		this.request( {
+		this.request({
 			path: this.path( "/worker/" + id + "/url.json" ),
 			method: "PUT"
 		}, data, fn );

--- a/readme.md
+++ b/readme.md
@@ -97,10 +97,10 @@ Change the URL of a worker.
 
 * `id`: The id of the worker.
 * `options`: Configuration for the URL change.
-  * `url`: The new URL to set, required.
-  * `timeout`: Increase the worker's timeout, optional.
+  * `url`: The new URL to set.
+  * `timeout` (optional): Set a new timeout for this worker, see [createWorker](#client.CreateWorker) for details.
 * `callback` (`function( error, data )`): A callback to invoke when the API call is complete.
-  * `data`: An object with a `message`, confirming the URL change
+  * `data`: An object with a `message`, confirming the URL change.
 
 ### client.terminateWorker( id, callback )
 


### PR DESCRIPTION
For POST and PUT requests content is now sent as JSON, as suggested by BrowserStack team.

The method name and signature could be improved, this is the best I could come up with.
