### PR TITLE
Add error handling to http request

### DIFF
--- a/lib/browserstack.js
+++ b/lib/browserstack.js
@@ -203,6 +203,8 @@ extend( Client.prototype, {
 		if ( data ) {
 			req.write( data );
 		}
+		
+		req.on('error', fn);
 		req.end();
 	},
 


### PR DESCRIPTION
Without this, when there is a network error, the process exists immediately.

With this, the callback is called with an error. Hurray!