### PR TITLE
Fixes issue with client.getLatest

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -72,7 +72,6 @@ extend(ApiBaseClient.prototype, {
 
 	getLatest: function(browser, fn) {
 		var latest = this.latest;
-		var browserId = this.getBrowserId(browser);
 
 		if (typeof browser === "function") {
 			fn = browser;
@@ -102,8 +101,8 @@ extend(ApiBaseClient.prototype, {
 		}
 
 		process.nextTick(function() {
-			fn(null, browser ? latest[browserId] : extend({}, latest));
-		});
+			fn(null, browser ? latest[this.getBrowserId(browser)] : extend({}, latest));
+		}.bind(this));
 	},
 
 	takeScreenshot: function(id, fn) {


### PR DESCRIPTION
Minor issue with `client.getLatest(function(err, versions) { ... })` as [described here](https://github.com/scottgonzalez/node-browserstack#clientgetlatest-callback-).

````
var BrowserStack = require('browserstack');

var client = BrowserStack.createClient({
  username: process.env.BROWSERSTACK_USERNAME,
  password: process.env.BROWSERSTACK_KEY
});

client.getLatest(console.log);
````


````
Shirishs-MacBook-Pro:tmp shirish$ node index.js
/repository/node-browserstac-test/tmp/node_modules/browserstack/lib/api.js:259
		var id = browser.os + ":" + browser.os_version + ":" + browser.browser;
		                ^

TypeError: Cannot read property 'os' of null
    at ApiClient.ApiBaseClient.createVersion.getBrowserId (/Users/shirish/repository/node-browserstack/tmp/node_modules/browserstack/lib/api.js:259:19)
    at ApiClient.extend.getLatest (/Users/shirish/repository/node-browserstack/tmp/node_modules/browserstack/lib/api.js:77:21)
    at ApiClient.<anonymous> (/Users/shirish/repository/node-browserstack/tmp/node_modules/browserstack/lib/api.js:102:10)
    at ApiClient.<anonymous> (/Users/shirish/repository/node-browserstack/tmp/node_modules/browserstack/lib/api.js:24:4)
    at IncomingMessage.<anonymous> (/Users/shirish/repository/node-browserstack/tmp/node_modules/browserstack/lib/client.js:75:5)
    at emitNone (events.js:72:20)
    at IncomingMessage.emit (events.js:166:7)
    at endReadableNT (_stream_readable.js:905:12)
    at doNTCallback2 (node.js:452:9)
    at process._tickCallback (node.js:366:17)
````