### PR TITLE
Add https proxy support

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -6,6 +6,7 @@ function ApiBaseClient(settings) {
 	this.server = {
 		host: "api.browserstack.com"
 	};
+	this.https_proxy = settings.https_proxy || null;
 	BaseClient.call(this, settings);
 }
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -6,7 +6,7 @@ function ApiBaseClient(settings) {
 	this.server = {
 		host: "api.browserstack.com"
 	};
-	this.https_proxy = settings.https_proxy || null;
+	this.proxy = settings.proxy || null;
 	BaseClient.call(this, settings);
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,6 +1,7 @@
 var https = require("https");
 var http = require("http");
 var extend = require("./extend");
+var HttpsProxyAgent = require('https-proxy-agent');
 var userAgent = getUA();
 
 function getUA() {
@@ -34,6 +35,8 @@ BaseClient.prototype.request = function(options, data, fn) {
 
 	fn = fn || function() {};
 
+	var agent = (this.https_proxy) ? new HttpsProxyAgent(this.https_proxy) : null;
+
 	var reqOptions = extend({
 		host: this.server.host,
 		port: this.server.port,
@@ -43,7 +46,8 @@ BaseClient.prototype.request = function(options, data, fn) {
 			"content-type": "application/json",
 			"user-agent": userAgent,
 			"content-length": typeof data === "string" ? data.length : 0
-		}
+		},
+		agent: agent
 	}, options);
 
 	var req = (this.useHttp ? http : https).request(reqOptions, function(res) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -35,7 +35,7 @@ BaseClient.prototype.request = function(options, data, fn) {
 
 	fn = fn || function() {};
 
-	var agent = (this.https_proxy) ? new HttpsProxyAgent(this.https_proxy) : null;
+	var agent = (this.proxy) ? new HttpsProxyAgent(this.proxy) : null;
 
 	var reqOptions = extend({
 		host: this.server.host,

--- a/lib/screenshot.js
+++ b/lib/screenshot.js
@@ -6,6 +6,7 @@ function ScreenshotClient(settings) {
 	this.server = {
 		host: "www.browserstack.com"
 	};
+	this.proxy = settings.proxy || null;
 	BaseClient.call(this, settings);
 }
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   "engines": {
     "node": ">=0.4.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "https-proxy-agent": "1.0.0"
+  },
   "devDependencies": {
     "jscs": "2.8.0",
     "jshint": "2.8.0"

--- a/readme.md
+++ b/readme.md
@@ -18,8 +18,7 @@ var BrowserStack = require( "browserstack" );
 // REST API
 var client = BrowserStack.createClient({
 	username: "foo",
-	password: "p455w0rd!!1",
-	proxy (optional): "http://myproxy.com:1234"
+	password: "p455w0rd!!1"
 });
 
 client.getBrowsers(function( error, browsers ) {
@@ -30,8 +29,7 @@ client.getBrowsers(function( error, browsers ) {
 // Screenshots API
 var screenshotClient = BrowserStack.createScreenshotClient({
 	username: "foo",
-	password: "p455w0rd!!1",
-	proxy (optional): "http://myproxy.com:1234"
+	password: "p455w0rd!!1"
 });
 
 screenshotClient.getBrowsers(function( error, browsers ) {
@@ -102,7 +100,7 @@ Creates a new client instance.
 	* `password`: The password for the BrowserStack account.
 	* `version` (optional; default: `4`): Which version of the BrowserStack API to use.
 	* `server` (optional; default: `{ host: "api.browserstack.com", port: 80 }`): An object containing `host` and `port` to connect to a different BrowserStack API compatible service.
-	* `proxy` (optional; default: `null`): A proxy server that should be used for communicating with 'server', e.g. 'proxy: "http://myproxy.com:1234"'
+	* `proxy` (optional; default: `null`): "http://myproxy.com:1234"
 
 #### client.getBrowsers( callback )
 

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ var BrowserStack = require( "browserstack" );
 var client = BrowserStack.createClient({
 	username: "foo",
 	password: "p455w0rd!!1",
-	https_proxy (optional): "http://myproxy.com:1234"
+	proxy (optional): "http://myproxy.com:1234"
 });
 
 client.getBrowsers(function( error, browsers ) {
@@ -30,7 +30,8 @@ client.getBrowsers(function( error, browsers ) {
 // Screenshots API
 var screenshotClient = BrowserStack.createScreenshotClient({
 	username: "foo",
-	password: "p455w0rd!!1"
+	password: "p455w0rd!!1",
+	proxy (optional): "http://myproxy.com:1234"
 });
 
 screenshotClient.getBrowsers(function( error, browsers ) {
@@ -101,6 +102,7 @@ Creates a new client instance.
 	* `password`: The password for the BrowserStack account.
 	* `version` (optional; default: `4`): Which version of the BrowserStack API to use.
 	* `server` (optional; default: `{ host: "api.browserstack.com", port: 80 }`): An object containing `host` and `port` to connect to a different BrowserStack API compatible service.
+	* `proxy` (optional; default: `null`): A proxy server that should be used for communicating with 'server', e.g. 'proxy: "http://myproxy.com:1234"'
 
 #### client.getBrowsers( callback )
 

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,8 @@ var BrowserStack = require( "browserstack" );
 // REST API
 var client = BrowserStack.createClient({
 	username: "foo",
-	password: "p455w0rd!!1"
+	password: "p455w0rd!!1",
+	https_proxy (optional): "http://myproxy.com:1234"
 });
 
 client.getBrowsers(function( error, browsers ) {


### PR DESCRIPTION
Hi Scott,

Sorry for the lack of documentation. I have updated the readme.md file with documentation. 

**reason for the new option:**
While being behind a (corporate) proxy I am not able to make direct http requests to browserstack without going through the proxy. In order to achieve this proxy support is desired.

**format of the option:**

settings {
proxy: "http://host:port"
}

**code example:**

var client = BrowserStack.createClient({
	username: "foo",
	password: "p455w0rd!!1",
	proxy: "http://myproxy.com:1234"
});

var screenshotClient = BrowserStack.createScreenshotClient({
	username: "foo",
	password: "p455w0rd!!1",
	proxy: "http://myproxy.com:1234"
});