### PR TITLE
JSCS config

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -26,6 +26,7 @@
         "allowUrlComments": true,
         "allowRegex": true
     },
+    "requireCamelCaseOrUpperCaseIdentifiers": false,
     "requireCommaBeforeLineBreak": true,
     "requireCurlyBraces": [
         "if",
@@ -41,6 +42,7 @@
     "requireLineFeedAtFileEnd": true,
     "requireOperatorBeforeLineBreak": true,
     "requirePaddingNewLinesBeforeLineComments": true,
+    "requirePaddingNewLinesAfterBlocks": false,
     "requireParenthesesAroundIIFE": true,
     "requireSemicolons": true,
     "requireSpaceAfterBinaryOperators": true,
@@ -68,7 +70,9 @@
     "requireSpacesInFunction": {
         "beforeOpeningCurlyBrace": true
     },
+    "requireTrailingComma": false,
     "requireSpacesInsideObjectBrackets": "all",
+    "validateIndentation": "\t",
     "validateLineBreaks": "LF",
     "validateQuoteMarks": "\""
 }


### PR DESCRIPTION
I got some errors thrown in the different source files by JSCS because some rules were missing.

I guess you have a global `.jscs` config which already implements these rules by default, which I don't as I never used JSCS on my office computer.