### PR TITLE
Add AppAutomateClient

### DIFF
--- a/lib/app-automate.js
+++ b/lib/app-automate.js
@@ -1,0 +1,119 @@
+var util = require("util");
+var querystring = require("querystring");
+var BaseClient = require("./client");
+var extend = require("./extend");
+
+function AppAutomateClient(settings) {
+	this.server = {
+		host: "api.browserstack.com"
+	};
+	BaseClient.call(this, settings);
+}
+
+util.inherits(AppAutomateClient, BaseClient);
+
+// public API
+extend(AppAutomateClient.prototype, {
+	getPlan: function(fn) {
+		this.request({
+			path: this.path("/plan.json")
+		}, fn);
+	},
+
+	getProjects: function(fn) {
+		this.request({
+			path: this.path("/projects.json")
+		}, this.handleResponse(fn, this.stripChildKeys("automation_project")));
+	},
+
+	getProject: function(id, fn) {
+		this.request({
+			path: this.path("/projects/" + id + ".json")
+		}, this.handleResponse(fn, function(project) {
+			project = project.project;
+			project.builds = this.stripChildKeys("automation_build")(project.builds);
+			return project;
+		}.bind(this)));
+	},
+
+	getBuilds: function(options, fn) {
+		if (typeof options === "function") {
+			fn = options;
+			options = {};
+		}
+
+		this.request({
+			path: this.path("/builds.json?" + querystring.stringify(options))
+		}, this.handleResponse(fn, this.stripChildKeys("automation_build")));
+	},
+
+	getSessions: function(buildId, options, fn) {
+		if (typeof fn === "undefined") {
+			fn = options;
+			options = {};
+		}
+
+		this.request({
+			path: this.path("/builds/" + buildId + "/sessions.json?" +
+				querystring.stringify(options))
+		}, this.handleResponse(fn, this.stripChildKeys("automation_session")));
+	},
+
+	getSession: function(id, fn) {
+		this.request({
+			path: this.path("/sessions/" + id + ".json")
+		}, this.handleResponse(fn, this.stripKey("automation_session")));
+	},
+
+	updateSession: function(id, options, fn) {
+		var data = JSON.stringify(options);
+		this.request({
+			method: "PUT",
+			path: this.path("/sessions/" + id + ".json")
+		}, data, this.handleResponse(fn, this.stripKey("automation_session")));
+	},
+
+	deleteSession: function(id, fn) {
+		this.request({
+			method: "DELETE",
+			path: this.path("/sessions/" + id + ".json")
+		}, fn);
+	}
+});
+
+// internal API
+extend(AppAutomateClient.prototype, {
+	path: function(path) {
+		return "/app-automate" + path;
+	},
+
+	handleResponse: function(fn, modifier) {
+		return function(error, data) {
+			if (error) {
+				return fn(error);
+			}
+
+			fn(null, modifier(data));
+		};
+	},
+
+	stripKey: function(key) {
+		return function(item) {
+			return item[key];
+		};
+	},
+
+	stripChildKeys: function(key) {
+		return function(items) {
+			return items.map(function(item) {
+				return item[key];
+			});
+		};
+	}
+});
+
+module.exports = {
+	createClient: function(settings) {
+		return new AppAutomateClient(settings);
+	}
+};

--- a/lib/browserstack.js
+++ b/lib/browserstack.js
@@ -1,9 +1,11 @@
 var browserstackApi = require("./api");
 var browserstackAutomate = require("./automate");
+var browserstackAppAutomate = require("./app-automate");
 var browserstackScreenshot = require("./screenshot");
 
 module.exports = {
 	createClient: browserstackApi.createClient,
 	createAutomateClient: browserstackAutomate.createClient,
+	createAppAutomateClient: browserstackAppAutomate.createClient,
 	createScreenshotClient: browserstackScreenshot.createClient
 };


### PR DESCRIPTION

The protractor BrowserStack driver (https://github.com/angular/protractor/blob/master/lib/driverProviders/browserStack.ts) is using this library to set the test result in BrowserStack. This work perfectly fine if we test browsers (Automate) but if we test apps (AppAutomate) the BrowserStack driver for protractor is not able to set the test result because this library only implements the Automate REST API and not also the AppAutomate API.

The AppAutomate and the Automate API have many functions in common but also some specialized functions and they have a different path ( '/automate' vs '/app-automate')

As the first solution, I've just copied the Automate class, renamed it in AppAutomated, changed the path and removed the `getBrowsers` method which is not present in the AppAutomate API.

But I would like to create a common class between `AppAutomate` and `Automate`, may be called `BaseAutomate`, which implement all shared methods between the two API and also define a common interface (very useful in the protractor BrowserStack driver).

@scottgonzalez let me know what do you think, and how can we implement this feature in the best way?