### PR TITLE
Update http-proxy-agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "bugs": "https://github.com/scottgonzalez/node-browserstack/issues",
   "license": "MIT",
   "dependencies": {
-    "https-proxy-agent": "^2.2.1"
+    "https-proxy-agent": "^3.0.0"
   },
   "devDependencies": {
     "jscs": "2.8.0",


### PR DESCRIPTION
Version @2.2.1 is vulnerable to machine in the middle attacks, https://www.npmjs.com/advisories/1184
Please update to 3.0.0 or greater.