### PR TITLE
Updated readme for app automate

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,15 @@ automateClient.getBrowsers(function(error, browsers) {
 	console.log(browsers);
 });
 
+// App Automate API
+// Show the upload builds for mobile app automation
+var appAutomateClient = BrowserStack.createAppAutomateClient(browserStackCredentials);
+
+appAutomateClient.getBuilds(function(error, builds) {
+	console.log("The following builds are available for app automated testing");
+	console.log(builds);
+});
+
 // Screenshots API
 var screenshotClient = BrowserStack.createScreenshotClient(browserStackCredentials);
 


### PR DESCRIPTION
-- README update for app automate.
-- getBrowsers is not available for App Automate. Using getBuilds as an example